### PR TITLE
Fix requirement mismatch between README and requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 decord>=0.6.0
 matplotlib
-mmcv==1.5.0
+mmcv-full==1.5.0
 moviepy
 numpy>=1.19.5
 opencv-contrib-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 decord>=0.6.0
 matplotlib
 mmcv-full==1.5.0
+mmpose
+mmdet
 moviepy
 numpy>=1.19.5
 opencv-contrib-python


### PR DESCRIPTION
Hello Haodong Duan,
thank you for this great work.

In the repository readme you mention _"Before running the demo, make sure you have installed mmcv-full, mmpose and mmdet. You should first install mmcv-full, and then install mmpose, mmdet."_

These kind of requirements should typically be part of the requirements.txt file. 

I struggled quite a while with this issue, as I of course installed all of the above and all packages mentioned in requirements.txt, leading to have both mmcv-full (current version) installed and mmcv (non-full, pinned version 1.5.0) -> This version mismatch can lead to non-helpful error messages, but fortunately the easy solution is to install the full version from the very beginning.

I also added the two other requirements (mmpose and mmdet) mentioned in the README to the _requirements.txt_ file, allowing everyone to run the demo without running into errors.

Total lines changed: 3

Kind regards
Alexander