### PR TITLE
fix: Add missing dependency on fvcore for demo_skeleton.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pymemcache
 scipy
 torch>=1.5
 tqdm
+fvcore


### PR DESCRIPTION
The demo_skeleton.py script requires the fvcore library to be installed, but this dependency was not listed in the requirements.txt file. As a result, users may encounter errors when trying to run the script.

This commit adds fvcore to the list of required packages in requirements.txt, ensuring that users can run demo_skeleton.py without encountering dependency issues.

Thanks for your attention to this matter!