### PR TITLE
[Data] Refine the skeleton extraction script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ This repo is the official implementation of [PoseConv3D](https://arxiv.org/abs/2
 </figure>
 </div>
 
-## News
+## Change Log
 
+- Improve skeleton extraction script ([PR](https://github.com/kennymckormick/pyskl/pull/150)). Now it supports non-distributed skeleton extraction and k400-style (**2023-03-20**).
 - Provide a real-time gesture recognition demo based on skeleton-based action recognition with ST-GCN++, check [Demo](/demo/demo.md) for more details and instructions (**2023-02-10**).
 - Provide [scripts](/examples/inference_speed.ipynb) to estimate the inference speed of each model (**2022-12-30**).
 - Support [RGBPoseConv3D](https://arxiv.org/abs/2104.13586), a two-stream 3D-CNN for action recognition based on RGB & Human Skeleton. Follow the [guide](/configs/rgbpose_conv3d/README.md) to train and test RGBPoseConv3D on NTURGB+D （**2022-12-29**).

--- a/pyskl/datasets/pose_dataset.py
+++ b/pyskl/datasets/pose_dataset.py
@@ -46,7 +46,7 @@ class PoseDataset(BaseDataset):
                  pipeline,
                  split=None,
                  valid_ratio=None,
-                 box_thr=0.5,
+                 box_thr=None,
                  class_prob=None,
                  memcached=False,
                  mc_cfg=('localhost', 22077),
@@ -65,13 +65,13 @@ class PoseDataset(BaseDataset):
 
         # Thresholding Training Examples
         self.valid_ratio = valid_ratio
-        if self.valid_ratio is not None:
-            assert isinstance(self.valid_ratio, float)
+        if self.valid_ratio is not None and isinstance(self.valid_ratio, float) and self.valid_ratio > 0:
             self.video_infos = [
                 x for x in self.video_infos
                 if x['valid'][self.box_thr] / x['total_frames'] >= valid_ratio
             ]
             for item in self.video_infos:
+                assert 'box_score' in item, 'if valid_ratio is a positive number, item should have field `box_score`'
                 anno_inds = (item['box_score'] >= self.box_thr)
                 item['anno_inds'] = anno_inds
         for item in self.video_infos:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 decord>=0.6.0
+fvcore
 matplotlib
 mmcv-full==1.5.0
 mmdet
@@ -11,4 +12,3 @@ pymemcache
 scipy
 torch>=1.5
 tqdm
-fvcore

--- a/tools/data/custom_2d_skeleton.py
+++ b/tools/data/custom_2d_skeleton.py
@@ -152,6 +152,7 @@ def main():
     assert det_model.CLASSES[0] == 'person', 'A detector trained on COCO is required'
     pose_model = init_pose_model(args.pose_config, args.pose_ckpt, 'cuda')
 
+    results = []
     for anno in tqdm(my_part):
         frames = extract_frame(anno['filename'])
         det_results = detection_inference(det_model, frames)
@@ -170,11 +171,12 @@ def main():
         anno['img_shape'] = shape
         anno = pose_inference(anno, pose_model, frames, det_results, compress=args.compress)
         anno.pop('filename')
+        results.append(anno)
 
     if args.non_dist:
-        mmcv.dump(my_part, args.out)
+        mmcv.dump(results, args.out)
     else:
-        mmcv.dump(my_part, osp.join(args.tmpdir, f'part_{rank}.pkl'))
+        mmcv.dump(results, osp.join(args.tmpdir, f'part_{rank}.pkl'))
         dist.barrier()
 
         if rank == 0:


### PR DESCRIPTION
1. Support non-distributed skeleton extraction by adding a `--non-dist` flag. With that flag, you can directly run the skeleton extraction python script: `python tools/data/custom_2d_skeleton.py {args} --non-dist`
2. Add a new option to generate compressed skeleton annotations (the K400 style). This can be achieved by set `--compress` and you will have a new filed name `frame_inds` in your generated annotations, indicates the frame index that each skeleton belongs to. 