### PR TITLE
Changed np.Inf to np.inf

### DIFF
--- a/demo/demo_skeleton.py
+++ b/demo/demo_skeleton.py
@@ -124,7 +124,7 @@ def frame_extraction(video_path, short_side):
     while flag:
         if new_h is None:
             h, w, _ = frame.shape
-            new_w, new_h = mmcv.rescale_size((w, h), (short_side, np.Inf))
+            new_w, new_h = mmcv.rescale_size((w, h), (short_side, np.inf))
 
         frame = mmcv.imresize(frame, (new_w, new_h))
 

--- a/pyskl/datasets/pipelines/augmentations.py
+++ b/pyskl/datasets/pipelines/augmentations.py
@@ -66,10 +66,10 @@ class PoseCompact:
         kp_x = kp[..., 0]
         kp_y = kp[..., 1]
 
-        min_x = np.min(kp_x[kp_x != 0], initial=np.Inf)
-        min_y = np.min(kp_y[kp_y != 0], initial=np.Inf)
-        max_x = np.max(kp_x[kp_x != 0], initial=-np.Inf)
-        max_y = np.max(kp_y[kp_y != 0], initial=-np.Inf)
+        min_x = np.min(kp_x[kp_x != 0], initial=np.inf)
+        min_y = np.min(kp_y[kp_y != 0], initial=np.inf)
+        max_x = np.max(kp_x[kp_x != 0], initial=-np.inf)
+        max_y = np.max(kp_y[kp_y != 0], initial=-np.inf)
 
         # The compact area is too small
         if max_x - min_x < self.threshold or max_y - min_y < self.threshold:

--- a/pyskl/datasets/pipelines/multi_modality.py
+++ b/pyskl/datasets/pipelines/multi_modality.py
@@ -149,10 +149,10 @@ class MMCompact:
         kp_x = keypoint[..., 0]
         kp_y = keypoint[..., 1]
 
-        min_x = np.min(kp_x[kp_x != 0], initial=np.Inf)
-        min_y = np.min(kp_y[kp_y != 0], initial=np.Inf)
-        max_x = np.max(kp_x[kp_x != 0], initial=-np.Inf)
-        max_y = np.max(kp_y[kp_y != 0], initial=-np.Inf)
+        min_x = np.min(kp_x[kp_x != 0], initial=np.inf)
+        min_y = np.min(kp_y[kp_y != 0], initial=np.inf)
+        max_x = np.max(kp_x[kp_x != 0], initial=-np.inf)
+        max_y = np.max(kp_y[kp_y != 0], initial=-np.inf)
 
         # The compact area is too small
         if max_x - min_x < self.threshold or max_y - min_y < self.threshold:


### PR DESCRIPTION
For `numpy >= 2.0.0`, `np.Inf` is deprecated and removed, causing the code to break.

It is instead replaced by `np.inf`. This PR addressed that.